### PR TITLE
Add Docker support (fixes Issue #102)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.6
+LABEL maintainer="wilddeej@gmail.com"
+
+ARG GIT_REPO=https://github.com/ellisonleao/pyshorteners.git
+ARG GIT_REPO_REV=master
+RUN \
+  git clone $GIT_REPO \
+  && cd pyshorteners \
+  && git checkout $GIT_REPO_REV \
+  && pip install -r requirements_test.txt \
+  && python setup.py install
+
+WORKDIR pyshorteners


### PR DESCRIPTION
Dockerfile added that allows building an image that contains pyshorteners as a micro-service.  This can also be leveraged for testing purposes or other useful things.

Building default image (assumes Docker has been fully installed and configured), from within the same directory where Dockerfile lives:
`docker build -t <tag_name> .`
...such as...
`docker build -t ellisonleao:pyshorteners .`

If some other git repository and/or branch/tag/SHA1 than the default (in the Dockerfile) is desired:
`docker build --build-arg GIT_REPO=<alternate_repo> --build-arg GIT_REPO_REV=<alternate_rev> -t <tag_name> .`
...such as...
`docker build --build-arg GIT_REPO=https://github.com/wilddeej/pyshorteners.git --build-arg GIT_REPO_REV=feature/Dockerfile -t wilddeej:pyshorteners .`

The resultant Docker image can be run via:
`docker run -it <tag_name> /bin/bash`
...such as...
`docker run -it ellisonleao:pyshorteners /bin/bash`
This will start up an interactive bash shell session within a container of the specified image tag, within the pyshorteners directory.  From here you can execute `make tests`, execute the default `example.py`, etc.