### PR TITLE
Added a new shortener for yourls http://yourls.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,5 +48,6 @@ print(s.tinyurl.short('www.google.com'))
 - soogd
 - tinycc
 - tinyurl
+- yourls
 
 Please checkout the [docs](http://pyshorteners.readthedocs.io/en/latest/) for more info and examples on how to use them.

--- a/pyshorteners/shorteners/yourls.py
+++ b/pyshorteners/shorteners/yourls.py
@@ -1,0 +1,128 @@
+import json
+
+from ..base import BaseShortener
+from ..exceptions import BadAPIResponseException, ShorteningErrorException
+
+
+class Shortener(BaseShortener):
+    """ Yourls shortener implementation
+
+    Args:
+        api_url: URL of the yourls API endpoint (http://server/yourls-api.php)
+        username: username
+        password: password
+
+    Example:
+
+        >>> import pyshorteners
+        >>> s = pyshorteners.Shortener(api_url='xxx', username='xxx',
+        password='xxx')
+        >>> s.yourls.short('http://www.google.com')
+        'http://server/test'
+        >>> s.yourls.expand('http://server/test')
+        'http://www.google.com'
+        >>> s.yourls.stats('http://server/test')
+        '2'
+    """
+
+    def short(self, url, custom=None, title=None):
+        """Short implementation for yourls
+        Args:
+            url: the URL you want to shorten
+            custom: the desired shortened URL
+            title: the title of this URL
+
+        Returns:
+            A string containing the shortened URL
+
+        Raises:
+            BadAPIResponseException: If the data is malformed or we got a bad
+            status code on API response
+            ShorteningErrorException: If the API Returns an error as response
+        """
+
+        payload = {
+            'username': getattr(self, 'username', ''),
+            'password': getattr(self, 'password', ''),
+            'format': 'json',
+            'action': 'shorturl',
+            'url': url
+        }
+
+        if custom:
+            payload['keyword'] = custom
+
+        if title:
+            payload['title'] = title
+
+        # shorten
+        response = self._post(self.api_url, data=payload)
+
+        if response.ok:
+            try:
+                return json.loads(response.text)['shorturl']
+            except (AttributeError, json.JSONDecodeError) as e:
+                raise ShorteningErrorException(str(e))
+
+        raise BadAPIResponseException(response.content)
+
+    def expand(self, url):
+        """Expand implementation for yourls
+        Args:
+            url: the URL you want to expand
+
+        Returns:
+            A string containing the expanded URL
+
+        Raises:
+            BadAPIResponseException: If the data is malformed or we got a bad
+            status code on API response
+            ShorteningErrorException: If the API Returns an error as response
+        """
+        payload = {
+            'username': getattr(self, 'username', ''),
+            'password': getattr(self, 'password', ''),
+            'format': 'json',
+            'action': 'expand',
+            'shorturl': url
+        }
+
+        # expand
+        response = self._post(self.api_url, data=payload)
+
+        if response.ok:
+            try:
+                return json.loads(response.text)['longurl']
+            except (KeyError, json.JSONDecodeError) as e:
+                raise ShorteningErrorException(str(e))
+        raise BadAPIResponseException(response.content)
+
+    def total_clicks(self, url):
+        """Total clicks implementation for yourls
+        Args:
+            url: the URL you want to get the total clicks count
+
+        Returns:
+            An int containing the total clicks count
+
+        Raises:
+            BadAPIResponseException: If the API Returns an error as response
+        """
+
+        payload = {
+            'username': getattr(self, 'username', ''),
+            'password': getattr(self, 'password', ''),
+            'format': 'json',
+            'action': 'url-stats',
+            'shorturl': url
+        }
+
+        # total clicks
+        response = self._post(self.api_url, data=payload)
+
+        if response.ok:
+            try:
+                return int(json.loads(response.text)['click'])
+            except (KeyError, json.JSONDecodeError, ValueError) as e:
+                raise ShorteningErrorException(str(e))
+        raise BadAPIResponseException(response.content)

--- a/tests/test_yourls.py
+++ b/tests/test_yourls.py
@@ -1,0 +1,96 @@
+import os
+
+import pytest
+import responses
+
+from pyshorteners import Shortener
+from pyshorteners.exceptions import BadAPIResponseException
+
+# Check and read from environment variables
+
+expected_environment_variables = [
+    "PYSHORTENERYOURLSTEST_USERNAME", "PYSHORTENERYOURLSTEST_PASSWORD",
+    "PYSHORTENERYOURLSTEST_APIURL", "PYSHORTENERYOURLSTEST_SHORTEN",
+    "PYSHORTENERYOURLSTEST_EXPANDED", "PYSHORTENERYOURLSTEST_TOTALCLICKS"
+]
+
+for expected_environment_variable in expected_environment_variables:
+    assert expected_environment_variable in os.environ, \
+        "Please set the environement variable %s to test `yourls`" % \
+        expected_environment_variable
+
+s = Shortener(
+    username=os.environ['PYSHORTENERYOURLSTEST_USERNAME'],
+    password=os.environ['PYSHORTENERYOURLSTEST_PASSWORD'],
+    api_url=os.environ['PYSHORTENERYOURLSTEST_APIURL'],
+)
+shorten = os.environ['PYSHORTENERYOURLSTEST_SHORTEN']
+expanded = os.environ['PYSHORTENERYOURLSTEST_EXPANDED']
+total_clicks = int(os.environ['PYSHORTENERYOURLSTEST_TOTALCLICKS'])
+yourls = s.yourls
+
+
+@responses.activate
+def test_yourls_short_method():
+    # mock responses
+    mock_url = f'{yourls.api_url}'
+    response = {
+        "shorturl": shorten,
+    }
+    responses.add(responses.POST, mock_url, json=response)
+    shorten_result = yourls.short(expanded)
+    assert shorten_result == shorten
+
+
+@responses.activate
+def test_yourls_short_method_bad_response():
+    # mock responses
+    mock_url = f'{yourls.api_url}'
+    responses.add(responses.POST, mock_url, status=400)
+
+    with pytest.raises(BadAPIResponseException):
+        yourls.short(expanded)
+
+
+@responses.activate
+def test_yourls_expand_method():
+    # mock responses
+    mock_url = f'{yourls.api_url}'
+    response = {
+        'longurl': expanded,
+    }
+    responses.add(responses.POST, mock_url, json=response)
+    expand_result = yourls.expand(shorten)
+    assert expand_result == expanded
+
+
+@responses.activate
+def test_yourls_expand_method_bad_response():
+    # mock responses
+    mock_url = f'{yourls.api_url}'
+    responses.add(responses.POST, mock_url, status=400)
+
+    with pytest.raises(BadAPIResponseException):
+        yourls.expand(expanded)
+
+
+@responses.activate
+def test_yourls_stats_method():
+    # mock responses
+    mock_url = f'{yourls.api_url}'
+    response = {
+        'click': total_clicks,
+    }
+    responses.add(responses.POST, mock_url, json=response)
+    total_clicks_result = yourls.total_clicks(shorten)
+    assert total_clicks_result == total_clicks
+
+
+@responses.activate
+def test_yourls_stats_method_bad_response():
+    # mock responses
+    mock_url = f'{yourls.api_url}'
+    responses.add(responses.POST, mock_url, status=400)
+
+    with pytest.raises(BadAPIResponseException):
+        yourls.total_clicks(shorten)


### PR DESCRIPTION
Follow up for #104 : here's a proposed implementation for a `yourls` shortener and the corresponding tests.

Testing a shortener requires an accessible server with a predictable output. AFAIK, such a public `yourls` server does not exist. The workaround I propose is to define parameters using environment variables:

- the server API endpoint
- username
- password
- short link
- expanded link 
- number of clicks

The test I implemented works with the following script (and fails with an appropriate message if one of these variables is not set):

```
PYSHORTENERYOURLSTEST_USERNAME="xxxx"
PYSHORTENERYOURLSTEST_PASSWORD="xxxx"
PYSHORTENERYOURLSTEST_APIURL="xxxxxxxxxxx"
PYSHORTENERYOURLSTEST_SHORTEN="xxxxxxxx"
PYSHORTENERYOURLSTEST_EXPANDED="xxxxxxxxxxxxxxxxxxxxxx"
PYSHORTENERYOURLSTEST_TOTALCLICKS="x"

export PYSHORTENERYOURLSTEST_USERNAME
export PYSHORTENERYOURLSTEST_PASSWORD
export PYSHORTENERYOURLSTEST_APIURL
export PYSHORTENERYOURLSTEST_SHORTEN
export PYSHORTENERYOURLSTEST_EXPANDED
export PYSHORTENERYOURLSTEST_TOTALCLICKS
```
