### PR TITLE
Add Null Pointer Shortener

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ print(s.tinyurl.short('www.google.com'))
 - clckru
 - dagd
 - isgd
+- nullpointer
 - osdb
 - owly
 - qpsru

--- a/pyshorteners/shorteners/nullpointer.py
+++ b/pyshorteners/shorteners/nullpointer.py
@@ -1,0 +1,47 @@
+from ..exceptions import BadAPIResponseException
+from ..base import BaseShortener
+
+
+class Shortener(BaseShortener):
+    """The Null Pointer implementation
+
+    Args:
+        domain: Optional string for the null pointer instance to use. Default is
+            'https://0x0.st'. Any URL to a Null Pointer instance is supported,
+            for example:
+
+                - https://0x0.st
+                - https://ttm.sh
+
+    Example:
+
+        >>> import pyshorteners
+        >>> s = pyshorteners.Shortener(domain='https://0x0.st')
+        >>> s.nullpointer.short('https://www.google.com')
+        'https://0x0.st/jU'
+    """
+
+    def short(self, url):
+        """Short implementation for The Null Pointer
+        Args:
+            url: the URL you want to shorten
+
+        Returns:
+            A string containing the shortened URL
+
+        Raises:
+            BadAPIResponseException: If the data is malformed or we got a bad
+            status code on API response
+        """
+        url = self.clean_url(url)
+        api_url = self.clean_url(getattr(self, 'domain', 'https://0x0.st'))
+        payload = {
+            "shorten": url
+        }
+
+        response = self._post(api_url, data=payload)
+
+        if not response.ok:
+            raise BadAPIResponseException(response.content)
+
+        return response.text

--- a/tests/test_nullpointer.py
+++ b/tests/test_nullpointer.py
@@ -1,0 +1,31 @@
+from pyshorteners import Shortener
+from pyshorteners.exceptions import BadAPIResponseException
+
+import responses
+import pytest
+
+s = Shortener(domain='https://0x0.st/')
+shorten = "https://0x0.st/jU"
+expanded = "https://www.google.com"
+nullpointer = s.nullpointer
+
+
+@responses.activate
+def test_nullpointer_short_method():
+    response = shorten
+    mock_url = nullpointer.domain
+    responses.add(responses.POST, mock_url, body=response)
+
+    shorten_result = nullpointer.short(expanded)
+
+    assert shorten_result == shorten
+
+
+@responses.activate
+def test_nullpointer_short_method_bad_response():
+    mock_url = nullpointer.domain
+    responses.add(responses.POST, mock_url, status=400)
+
+    with pytest.raises(BadAPIResponseException):
+        nullpointer.short(expanded)
+        


### PR DESCRIPTION
I wanted to add one of my preferred URL Shorteners: The Null Pointer. It's open source so there are many instances of it dotted around the web, like at: https://0x0.st/ and https://ttm.sh/, so I made it work with any instance.

This PR is for Hacktoberfest. If there's any problems, let me know :smile: