### PR TITLE
feat: Auto-generate API docs

### DIFF
--- a/docs/apis.rst
+++ b/docs/apis.rst
@@ -8,18 +8,21 @@ Adf.ly
 
 .. autoclass:: pyshorteners.shorteners.adfly.Shortener
     :members:
+    :noindex:
 
 Bit.ly
 ------
 
 .. autoclass:: pyshorteners.shorteners.bitly.Shortener
     :members:
+    :noindex:
 
 TinyURL.com
 -----------
 
 .. autoclass:: pyshorteners.shorteners.tinyurl.Shortener
     :members:
+    :noindex:
 
 
 Git.io
@@ -27,3 +30,4 @@ Git.io
 
 .. autoclass:: pyshorteners.shorteners.gitio.Shortener
     :members:
+    :noindex:

--- a/docs/apis/modules.rst
+++ b/docs/apis/modules.rst
@@ -1,0 +1,7 @@
+pyshorteners
+============
+
+.. toctree::
+   :maxdepth: 4
+
+   pyshorteners

--- a/docs/apis/pyshorteners.rst
+++ b/docs/apis/pyshorteners.rst
@@ -1,0 +1,34 @@
+pyshorteners package
+====================
+
+.. automodule:: pyshorteners
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Subpackages
+-----------
+
+.. toctree::
+
+   pyshorteners.shorteners
+
+Submodules
+----------
+
+pyshorteners.base module
+------------------------
+
+.. automodule:: pyshorteners.base
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+pyshorteners.exceptions module
+------------------------------
+
+.. automodule:: pyshorteners.exceptions
+   :members:
+   :undoc-members:
+   :show-inheritance:
+

--- a/docs/apis/pyshorteners.shorteners.rst
+++ b/docs/apis/pyshorteners.shorteners.rst
@@ -1,0 +1,131 @@
+pyshorteners.shorteners package
+===============================
+
+.. automodule:: pyshorteners.shorteners
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Submodules
+----------
+
+pyshorteners.shorteners.adfly module
+------------------------------------
+
+.. automodule:: pyshorteners.shorteners.adfly
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+pyshorteners.shorteners.bitly module
+------------------------------------
+
+.. automodule:: pyshorteners.shorteners.bitly
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+pyshorteners.shorteners.chilpit module
+--------------------------------------
+
+.. automodule:: pyshorteners.shorteners.chilpit
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+pyshorteners.shorteners.clckru module
+-------------------------------------
+
+.. automodule:: pyshorteners.shorteners.clckru
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+pyshorteners.shorteners.dagd module
+-----------------------------------
+
+.. automodule:: pyshorteners.shorteners.dagd
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+pyshorteners.shorteners.gitio module
+------------------------------------
+
+.. automodule:: pyshorteners.shorteners.gitio
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+pyshorteners.shorteners.isgd module
+-----------------------------------
+
+.. automodule:: pyshorteners.shorteners.isgd
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+pyshorteners.shorteners.nullpointer module
+------------------------------------------
+
+.. automodule:: pyshorteners.shorteners.nullpointer
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+pyshorteners.shorteners.osdb module
+-----------------------------------
+
+.. automodule:: pyshorteners.shorteners.osdb
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+pyshorteners.shorteners.owly module
+-----------------------------------
+
+.. automodule:: pyshorteners.shorteners.owly
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+pyshorteners.shorteners.post module
+-----------------------------------
+
+.. automodule:: pyshorteners.shorteners.post
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+pyshorteners.shorteners.qpsru module
+------------------------------------
+
+.. automodule:: pyshorteners.shorteners.qpsru
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+pyshorteners.shorteners.soogd module
+------------------------------------
+
+.. automodule:: pyshorteners.shorteners.soogd
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+pyshorteners.shorteners.tinycc module
+-------------------------------------
+
+.. automodule:: pyshorteners.shorteners.tinycc
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+pyshorteners.shorteners.tinyurl module
+--------------------------------------
+
+.. automodule:: pyshorteners.shorteners.tinyurl
+   :members:
+   :undoc-members:
+   :show-inheritance:
+

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,6 +13,7 @@ import datetime
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
 import os
+import subprocess
 import sys
 sys.path.insert(0, os.path.abspath('.'))
 
@@ -169,3 +170,7 @@ texinfo_documents = [
 
 
 # -- Extension configuration -------------------------------------------------
+
+subprocess.run(
+    "sphinx-apidoc --force --module-first --output-dir apis ../pyshorteners/", check=True, shell=True
+)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,3 +26,4 @@ Contents
 
     apis
     contributing
+    apis/modules.rst


### PR DESCRIPTION
Use `sphinx-apidoc` to auto-generate the full Python API documentation.

See also: #137