### PR TITLE
Add cleanUrl paramater in the supported sites

### DIFF
--- a/pyshorteners/base.py
+++ b/pyshorteners/base.py
@@ -42,6 +42,7 @@ class BaseShortener:
         self.verify = getattr(self, "verify", True)
         self.proxies = getattr(self, "proxies", {})
         self.cert = getattr(self, "cert", None)
+        self.clean = getattr(self, "clean", True)
 
     def _get(self, url, params=None, headers=None):
         """Wrap a GET request with a url check.
@@ -137,8 +138,7 @@ class BaseShortener:
             return response.url
         raise ExpandingErrorException
 
-    @staticmethod
-    def clean_url(url):
+    def clean_url(self, url):
         """URL validation.
 
         Args:
@@ -148,6 +148,9 @@ class BaseShortener:
             BadURLException: URL is not valid.
 
         """
+        if not self.clean:
+            return url 
+            
         if not url.startswith(("http://", "https://")):
             url = f"http://{url}"
 

--- a/pyshorteners/base.py
+++ b/pyshorteners/base.py
@@ -42,7 +42,6 @@ class BaseShortener:
         self.verify = getattr(self, "verify", True)
         self.proxies = getattr(self, "proxies", {})
         self.cert = getattr(self, "cert", None)
-        self.clean = getattr(self, "clean", True)
 
     def _get(self, url, params=None, headers=None):
         """Wrap a GET request with a url check.
@@ -138,7 +137,7 @@ class BaseShortener:
             return response.url
         raise ExpandingErrorException
 
-    def clean_url(self, url):
+    def clean_url(self, url, clean_url=True):
         """URL validation.
 
         Args:
@@ -148,7 +147,7 @@ class BaseShortener:
             BadURLException: URL is not valid.
 
         """
-        if not self.clean:
+        if not clean_url:
             return url 
             
         if not url.startswith(("http://", "https://")):

--- a/pyshorteners/shorteners/adfly.py
+++ b/pyshorteners/shorteners/adfly.py
@@ -41,7 +41,7 @@ class Shortener(BaseShortener):
 
     api_url = "http://api.adf.ly/v1"
 
-    def short(self, url):
+    def short(self, url, clean_url=True):
         """Short implementation for Adf.ly.
 
         Args:
@@ -56,7 +56,7 @@ class Shortener(BaseShortener):
             ShorteningErrorException: If the API Returns an error as response.
 
         """
-        url = self.clean_url(url)
+        url = self.clean_url(url, clean_url)
         shorten_url = f"{self.api_url}/shorten"
         payload = {
             "domain": getattr(self, "domain", "adf.ly"),

--- a/pyshorteners/shorteners/bitly.py
+++ b/pyshorteners/shorteners/bitly.py
@@ -32,7 +32,7 @@ class Shortener(BaseShortener):
 
     api_url = "https://api-ssl.bit.ly/v4"
 
-    def short(self, url):
+    def short(self, url, clean_url=True):
         """Short implementation for Bit.ly
         Args:
             url (str): the URL you want to shorten
@@ -45,7 +45,7 @@ class Shortener(BaseShortener):
                 status code on API response.
             ShorteningErrorException: If the API Returns an error as response
         """
-        self.clean_url(url)
+        url = self.clean_url(url, clean_url)
         shorten_url = f"{self.api_url}/shorten"
         params = {"long_url": url}
         headers = {"Authorization": f"Bearer {self.api_key}"}

--- a/pyshorteners/shorteners/chilpit.py
+++ b/pyshorteners/shorteners/chilpit.py
@@ -18,7 +18,7 @@ class Shortener(BaseShortener):
 
     api_url = "http://chilp.it/api.php"
 
-    def short(self, url):
+    def short(self, url, clean_url=True):
         """Short implementation for Chilp.it
 
         Args:
@@ -30,6 +30,8 @@ class Shortener(BaseShortener):
         Raises:
             ShorteningErrorException: If the API returns an error as response
         """
+        
+        url = self.clean_url(url, clean_url)
         response = self._get(self.api_url, params={"url": url})
         if response.ok:
             return response.text.strip()

--- a/pyshorteners/shorteners/clckru.py
+++ b/pyshorteners/shorteners/clckru.py
@@ -19,7 +19,7 @@ class Shortener(BaseShortener):
 
     api_url = "https://clck.ru/--"
 
-    def short(self, url):
+    def short(self, url, clean_url=True):
         """Short implementation for Clck.ru
 
         Args:
@@ -32,6 +32,7 @@ class Shortener(BaseShortener):
             ShorteningErrorException: If the API returns an error as response
         """
 
+        url = self.clean_url(url, clean_url)
         response = self._get(self.api_url, params={"url": url})
         if response.ok:
             return response.text.strip()

--- a/pyshorteners/shorteners/cuttly.py
+++ b/pyshorteners/shorteners/cuttly.py
@@ -23,7 +23,7 @@ class Shortener(BaseShortener):
     api_url = "https://cutt.ly/api/api.php"
     STATUS_INVALID = 4
 
-    def short(self, url):
+    def short(self, url, clean_url=True):
         """Short implementation for Cutt.ly
         Args:
             url (str): the URL you want to shorten
@@ -36,7 +36,7 @@ class Shortener(BaseShortener):
                 status code on API response.
             ShorteningErrorException: If the API Returns an error as response
         """
-        url = self.clean_url(url)
+        url = self.clean_url(url, clean_url)
         response = self._get(self.api_url, params={"key": self.api_key, "short": url})
         try:
             data = response.json()

--- a/pyshorteners/shorteners/dagd.py
+++ b/pyshorteners/shorteners/dagd.py
@@ -18,7 +18,7 @@ class Shortener(BaseShortener):
 
     api_url = "https://da.gd/"
 
-    def short(self, url):
+    def short(self, url, clean_url=True):
         """Short implementation for Da.gd
         Args:
             url (str): the URL you want to shorten
@@ -29,7 +29,7 @@ class Shortener(BaseShortener):
         Raises:
             ShorteningErrorException: If the API Returns an error as response
         """
-        url = self.clean_url(url)
+        url = self.clean_url(url, clean_url)
         shorten_url = f"{self.api_url}shorten"
         response = self._get(shorten_url, params={"url": url})
         if not response.ok:

--- a/pyshorteners/shorteners/gitio.py
+++ b/pyshorteners/shorteners/gitio.py
@@ -17,7 +17,7 @@ class Shortener(BaseShortener):
 
     api_url = "https://git.io"
 
-    def short(self, url):
+    def short(self, url, clean_url=True):
         """Short implementation for Git.io
         Only works for github urls
 
@@ -37,6 +37,7 @@ class Shortener(BaseShortener):
         except AttributeError:
             pass
 
+        url = self.clean_url(url, clean_url)
         shorten_url = self.api_url
         data = {"url": url, "code": code}
         response = self._post(shorten_url, data=data)

--- a/pyshorteners/shorteners/isgd.py
+++ b/pyshorteners/shorteners/isgd.py
@@ -19,11 +19,12 @@ class Shortener(BaseShortener):
 
     api_url = "https://is.gd/create.php"
 
-    def short(self, url):
+    def short(self, url, cleanUrl=True):
         """Short implementation for Is.gd
 
         Args:
             url: the URL you want to shorten
+            cleanUrl: boolean to clean URL or not
 
         Returns:
             A string containing the shortened URL
@@ -32,7 +33,7 @@ class Shortener(BaseShortener):
             ShorteningErrorException: If the API returns an error as response
         """
 
-        url = self.clean_url(url)
+        url = self.clean_url(url) if cleanUrl else url
         params = {"format": "simple", "url": url}
         response = self._get(self.api_url, params=params)
         if response.ok:

--- a/pyshorteners/shorteners/isgd.py
+++ b/pyshorteners/shorteners/isgd.py
@@ -19,12 +19,11 @@ class Shortener(BaseShortener):
 
     api_url = "https://is.gd/create.php"
 
-    def short(self, url, cleanUrl=True):
+    def short(self, url):
         """Short implementation for Is.gd
 
         Args:
             url: the URL you want to shorten
-            cleanUrl: boolean to clean URL or not
 
         Returns:
             A string containing the shortened URL
@@ -33,7 +32,7 @@ class Shortener(BaseShortener):
             ShorteningErrorException: If the API returns an error as response
         """
 
-        url = self.clean_url(url) if cleanUrl else url
+        url = self.clean_url(url)
         params = {"format": "simple", "url": url}
         response = self._get(self.api_url, params=params)
         if response.ok:

--- a/pyshorteners/shorteners/isgd.py
+++ b/pyshorteners/shorteners/isgd.py
@@ -19,7 +19,7 @@ class Shortener(BaseShortener):
 
     api_url = "https://is.gd/create.php"
 
-    def short(self, url):
+    def short(self, url, clean_url=True):
         """Short implementation for Is.gd
 
         Args:
@@ -32,7 +32,7 @@ class Shortener(BaseShortener):
             ShorteningErrorException: If the API returns an error as response
         """
 
-        url = self.clean_url(url)
+        url = self.clean_url(url, clean_url)
         params = {"format": "simple", "url": url}
         response = self._get(self.api_url, params=params)
         if response.ok:

--- a/pyshorteners/shorteners/nullpointer.py
+++ b/pyshorteners/shorteners/nullpointer.py
@@ -21,7 +21,7 @@ class Shortener(BaseShortener):
         'https://0x0.st/jU'
     """
 
-    def short(self, url):
+    def short(self, url, clean_url=True):
         """Short implementation for The Null Pointer
         Args:
             url (str): the URL you want to shorten
@@ -33,7 +33,7 @@ class Shortener(BaseShortener):
             ShorteningErrorException: If the data is malformed or we got a bad
             status code on API response
         """
-        url = self.clean_url(url)
+        url = self.clean_url(url, clean_url)
         api_url = self.clean_url(getattr(self, "domain", "https://0x0.st"))
         payload = {"shorten": url}
 

--- a/pyshorteners/shorteners/osdb.py
+++ b/pyshorteners/shorteners/osdb.py
@@ -40,7 +40,7 @@ class Shortener(BaseShortener):
 
     api_url = "https://osdb.link/"
 
-    def short(self, url):
+    def short(self, url, clean_url=True):
         """Short implementation for Os.db
 
         Args:
@@ -52,7 +52,7 @@ class Shortener(BaseShortener):
         Raises:
             ShorteningErrorException: If the API returns an error as response
         """
-        url = self.clean_url(url)
+        url = self.clean_url(url, clean_url)
         response = self._post(self.api_url, data={"url": url})
         if not response.ok:
             raise ShorteningErrorException(response.content)

--- a/pyshorteners/shorteners/owly.py
+++ b/pyshorteners/shorteners/owly.py
@@ -22,7 +22,7 @@ class Shortener(BaseShortener):
 
     api_url = "http://ow.ly/api/1.1/url/"
 
-    def short(self, url):
+    def short(self, url, clean_url=True):
         """Short implementation for ow.ly.
 
         Args:
@@ -36,7 +36,7 @@ class Shortener(BaseShortener):
             ShorteningErrorException: If the API Returns an error as response.
         """
 
-        url = self.clean_url(url)
+        url = self.clean_url(url, clean_url)
         shorten_url = f"{self.api_url}shorten"
         params = {"apiKey": self.api_key, "longUrl": url}
         response = self._get(shorten_url, params=params)

--- a/pyshorteners/shorteners/post.py
+++ b/pyshorteners/shorteners/post.py
@@ -23,7 +23,7 @@ class Shortener(BaseShortener):
 
     api_url = "http://po.st/api/shorten"
 
-    def short(self, url):
+    def short(self, url, clean_url=True):
         """Short implementation for Po.st.
 
         Args:
@@ -38,7 +38,7 @@ class Shortener(BaseShortener):
             ShorteningErrorException: If the API Returns an error as response.
 
         """
-        url = self.clean_url(url)
+        url = self.clean_url(url, clean_url)
         params = {"apiKey": self.api_key, "longUrl": url, "format": "txt"}
         response = self._get(self.api_url, params=params)
         if not response.ok:

--- a/pyshorteners/shorteners/qpsru.py
+++ b/pyshorteners/shorteners/qpsru.py
@@ -19,7 +19,7 @@ class Shortener(BaseShortener):
 
     api_url = "http://qps.ru/api"
 
-    def short(self, url):
+    def short(self, url, clean_url=True):
         """Short implementation for Qps.ru
 
         Args:
@@ -32,7 +32,7 @@ class Shortener(BaseShortener):
             ShorteningErrorException: If the API returns an error as response
         """
 
-        url = self.clean_url(url)
+        url = self.clean_url(url, clean_url)
         response = self._get(self.api_url, params={"url": url})
         if not response.ok:
             raise ShorteningErrorException(response.content)

--- a/pyshorteners/shorteners/shortcm.py
+++ b/pyshorteners/shorteners/shortcm.py
@@ -31,7 +31,7 @@ class Shortener(BaseShortener):
     domain = ""
     api_key = ""
 
-    def short(self, url):
+    def short(self, url, clean_url=True):
         """Short implementation for Short.cm
         Args:
             url (str): the URL you want to shorten
@@ -45,7 +45,7 @@ class Shortener(BaseShortener):
             ShorteningErrorException: If the API Returns an error as response
         """
 
-        self.clean_url(url)
+        self.clean_url(url, clean_url)
         json = {"originalURL": url, "domain": self.domain}
         headers = {"authorization": self.api_key}
         response = self._post(self.api_url, json=json, headers=headers)

--- a/pyshorteners/shorteners/tinycc.py
+++ b/pyshorteners/shorteners/tinycc.py
@@ -27,7 +27,7 @@ class Shortener(BaseShortener):
         "User-Agent": "Mozilla/5.0 (X11; Ubuntu; Linux) Gecko/20100101 " "Firefox/61.0"
     }
 
-    def short(self, url):
+    def short(self, url, clean_url=True):
         """Short implementation for Tiny.cc.
 
         Args:
@@ -43,7 +43,7 @@ class Shortener(BaseShortener):
                 response.
 
         """
-        url = self.clean_url(url)
+        url = self.clean_url(url, clean_url)
         params = self.params.copy()
         params.update(
             {

--- a/pyshorteners/shorteners/tinyurl.py
+++ b/pyshorteners/shorteners/tinyurl.py
@@ -18,12 +18,11 @@ class Shortener(BaseShortener):
 
     api_url = "http://tinyurl.com/api-create.php"
 
-    def short(self, url, cleanUrl=True):
+    def short(self, url):
         """Short implementation for TinyURL.com
 
         Args:
             url: the URL you want to shorten
-            cleanUrl: boolean to clean URL or not
 
         Returns:
             A string containing the shortened URL
@@ -31,7 +30,7 @@ class Shortener(BaseShortener):
         Raises:
             ShorteningErrorException: If the API returns an error as response
         """
-        url = self.clean_url(url) if cleanUrl else url
+        url = self.clean_url(url)
         response = self._get(self.api_url, params=dict(url=url))
         if response.ok:
             return response.text.strip()

--- a/pyshorteners/shorteners/tinyurl.py
+++ b/pyshorteners/shorteners/tinyurl.py
@@ -18,11 +18,12 @@ class Shortener(BaseShortener):
 
     api_url = "http://tinyurl.com/api-create.php"
 
-    def short(self, url):
+    def short(self, url, cleanUrl=True):
         """Short implementation for TinyURL.com
 
         Args:
             url: the URL you want to shorten
+            cleanUrl: boolean to clean URL or not
 
         Returns:
             A string containing the shortened URL
@@ -30,7 +31,7 @@ class Shortener(BaseShortener):
         Raises:
             ShorteningErrorException: If the API returns an error as response
         """
-        url = self.clean_url(url)
+        url = self.clean_url(url) if cleanUrl else url
         response = self._get(self.api_url, params=dict(url=url))
         if response.ok:
             return response.text.strip()

--- a/pyshorteners/shorteners/tinyurl.py
+++ b/pyshorteners/shorteners/tinyurl.py
@@ -18,7 +18,7 @@ class Shortener(BaseShortener):
 
     api_url = "http://tinyurl.com/api-create.php"
 
-    def short(self, url):
+    def short(self, url, clean_url=True):
         """Short implementation for TinyURL.com
 
         Args:
@@ -30,7 +30,7 @@ class Shortener(BaseShortener):
         Raises:
             ShorteningErrorException: If the API returns an error as response
         """
-        url = self.clean_url(url)
+        url = self.clean_url(url, clean_url)
         response = self._get(self.api_url, params=dict(url=url))
         if response.ok:
             return response.text.strip()


### PR DESCRIPTION
Hi there, I wanted to shorten a magnet link that starts with magnet:? but the clean_url method is adding http or https before the link. So, I added a cleanUrl argument that defines whether to clean the URL or not. 

I checked all the supported sites by pyshorteners and only Tinyurl.com & is.gd allows link without http or https. So, I added the cleanUrl argument in those sites only.

By default, cleanUrl is True so it won't break any existing projects.😇